### PR TITLE
Add preset rename and reorder

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser": "^17.0.0",
     "@angular/platform-browser-dynamic": "^17.0.0",
     "@angular/router": "^17.0.0",
+    "@angular/cdk": "^17.0.0",
     "@tauri-apps/api": "2",
     "@tauri-apps/plugin-dialog": "2",
     "rxjs": "~7.8.0",

--- a/src/app/components/prompt-composer/prompt-composer.component.html
+++ b/src/app/components/prompt-composer/prompt-composer.component.html
@@ -227,23 +227,60 @@
 					</button>
 				</div>
 			</div>
-			<div class="space-y-1.5 max-h-[300px] overflow-y-auto">
+			<div
+				class="space-y-1.5 max-h-[300px] overflow-y-auto"
+				cdkDropList
+				cdkDropListOrientation="vertical"
+				(cdkDropListDropped)="dropPreset($event)"
+			>
 				<div
 					*ngFor="let preset of presets"
+					cdkDrag
+					cdkDragLockAxis="y"
 					class="bg-darkprimary/20 border border-neutral-700/30 px-3 py-2 rounded-lg hover:bg-neutral-700/30 transition-all flex justify-between items-center group text-sm"
 					(click)="loadPreset(preset)"
 				>
-					<span>{{ preset.name }}</span>
-					<button
-						(click)="deletePreset($event, preset.id)"
-						class="text-red-400 opacity-0 group-hover:opacity-100 transition-all hover:text-red-500 p-1 hover:bg-red-500/10 rounded-md"
-					>
+					<div class="flex items-center gap-2">
 						<img
-							src="assets/icons/trash.svg"
-							alt="delete"
-							class="w-3.5 h-3.5"
+							src="assets/icons/handle.svg"
+							alt="drag"
+							cdkDragHandle
+							class="w-3 h-3 opacity-60 cursor-grab"
+							(click)="$event.stopPropagation()"
 						/>
-					</button>
+						<span *ngIf="editingPresetId !== preset.id">{{
+							preset.name
+						}}</span>
+						<input
+							*ngIf="editingPresetId === preset.id"
+							[(ngModel)]="editingPresetName"
+							(keyup.enter)="renamePreset()"
+							(click)="$event.stopPropagation()"
+							class="bg-darkbg rounded px-1 py-0.5 text-xs focus:outline-none"
+						/>
+					</div>
+					<div class="flex items-center gap-1">
+						<button
+							(click)="startRename($event, preset)"
+							class="opacity-0 group-hover:opacity-100 transition-all p-1 hover:bg-neutral-700/50 rounded-md"
+						>
+							<img
+								src="assets/icons/pencil.svg"
+								alt="edit"
+								class="w-3.5 h-3.5"
+							/>
+						</button>
+						<button
+							(click)="deletePreset($event, preset.id)"
+							class="text-red-400 opacity-0 group-hover:opacity-100 transition-all hover:text-red-500 p-1 hover:bg-red-500/10 rounded-md"
+						>
+							<img
+								src="assets/icons/trash.svg"
+								alt="delete"
+								class="w-3.5 h-3.5"
+							/>
+						</button>
+					</div>
 				</div>
 				<div
 					*ngIf="presets.length === 0"

--- a/src/app/services/preset.service.ts
+++ b/src/app/services/preset.service.ts
@@ -11,7 +11,7 @@ export interface PromptPreset {
 	providedIn: "root",
 })
 export class PresetService {
-	private readonly PRESETS_KEY = "promptPresets";
+    private readonly PRESETS_KEY = "promptPresets";
 
 	getPresets(): PromptPreset[] {
 		const presetsJson = localStorage.getItem(this.PRESETS_KEY);
@@ -35,9 +35,22 @@ export class PresetService {
 		return newPreset;
 	}
 
-	deletePreset(id: string): void {
-		const presets = this.getPresets();
-		const updatedPresets = presets.filter((preset) => preset.id !== id);
-		localStorage.setItem(this.PRESETS_KEY, JSON.stringify(updatedPresets));
-	}
+    deletePreset(id: string): void {
+        const presets = this.getPresets();
+        const updatedPresets = presets.filter((preset) => preset.id !== id);
+        localStorage.setItem(this.PRESETS_KEY, JSON.stringify(updatedPresets));
+    }
+
+    renamePreset(id: string, name: string): void {
+        const presets = this.getPresets();
+        const preset = presets.find((p) => p.id === id);
+        if (preset) {
+            preset.name = name;
+            localStorage.setItem(this.PRESETS_KEY, JSON.stringify(presets));
+        }
+    }
+
+    reorderPresets(presets: PromptPreset[]): void {
+        localStorage.setItem(this.PRESETS_KEY, JSON.stringify(presets));
+    }
 }

--- a/src/assets/icons/handle.svg
+++ b/src/assets/icons/handle.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#c4cad4" class="lucide lucide-grip-vertical">
+  <circle cx="9" cy="12" r="2"/>
+  <circle cx="9" cy="5" r="2"/>
+  <circle cx="9" cy="19" r="2"/>
+  <circle cx="15" cy="12" r="2"/>
+  <circle cx="15" cy="5" r="2"/>
+  <circle cx="15" cy="19" r="2"/>
+</svg>

--- a/src/assets/icons/pencil.svg
+++ b/src/assets/icons/pencil.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#c4cad4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-pencil"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>

--- a/src/assets/styles/input.css
+++ b/src/assets/styles/input.css
@@ -22,3 +22,8 @@ html::-webkit-scrollbar-thumb {
   background-color: #6267ec;
   border-radius: 10px;
 }
+
+/* Preserve text color while dragging */
+.cdk-drag-preview {
+  color: #c4cad4;
+}


### PR DESCRIPTION
## Summary
- allow renaming and reordering of saved presets
- import DragDropModule for drag and drop
- add preset rename/edit logic
- add drag handles and pencil icons
- persist preset order
- include handle.svg and pencil.svg icons

## Testing
- `npm run build` *(fails: Cannot find module '@angular/cdk/drag-drop')*

------
https://chatgpt.com/codex/tasks/task_e_685c6cb5e2388331a18ef82b4f7db04c